### PR TITLE
Fixing grabbers that were no longer working

### DIFF
--- a/src/SharpGrabber/Internal/Grabbers/InstagramGrabber.cs
+++ b/src/SharpGrabber/Internal/Grabbers/InstagramGrabber.cs
@@ -1,0 +1,177 @@
+using DotNetTools.SharpGrabber.Exceptions;
+using DotNetTools.SharpGrabber.Media;
+using HtmlAgilityPack;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DotNetTools.SharpGrabber.Internal.Grabbers
+{
+    /// <summary>
+    /// Represents an Instagram <see cref="IGrabber"/>.
+    /// </summary>
+    public class InstagramGrabber : BaseGrabber
+    {
+        #region Fields
+
+        private readonly Regex _idPattern =
+            new Regex(@"^https?://(www\.)?instagram\.com/\w/([A-Za-z0-9_-]+)(/.*)?$",
+                RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        private readonly Regex _graphqlScriptRegex = new Regex(@"<script[^<>]+>([^<>]+)graphql([^<>]+)</script>");
+
+        #endregion
+
+        #region Properties
+
+        /// <inheritdoc />
+        public override string Name { get; } = "Instagram";
+
+        /// <summary>
+        /// Represents the template of standard Instagram links. This value will be formatted using <see cref="String.Format(string, object[])"/>
+        /// passing an Instagram post identifier containing alpha-numeric characters.
+        /// </summary>
+        public virtual string StandardUrlTemplate { get; set; } = "https://www.instagram.com/p/{0}/";
+
+        #endregion
+
+        #region Internal Methods
+
+        /// <summary>
+        /// Makes a standard Instagram URL using the given post ID.
+        /// </summary>
+        protected virtual Uri MakeStandardInstagramUri(string id) => new Uri(string.Format(StandardUrlTemplate, id));
+
+        /// <summary>
+        /// Extracts post ID from the specified URI.
+        /// </summary>
+        protected virtual string GrabId(Uri uri)
+        {
+            var uriString = uri.ToString();
+            var match = _idPattern.Match(uriString);
+            if (!match.Success)
+                return null;
+            return match.Groups[2].Value;
+        }
+
+        /// <summary>
+        /// Validates response of the page request. For example, in the beginning the returned status code is checked.
+        /// </summary>
+        protected virtual void CheckResponse(HttpResponseMessage response)
+        {
+            if (response.StatusCode != HttpStatusCode.OK)
+                throw new GrabException(
+                    $"An HTTP error occurred while retrieving Instagram content. Server returned {response.StatusCode} {response.ReasonPhrase}.");
+        }
+
+        /// <summary>
+        /// Parses content of the page and retrieves meta tags with useful information.
+        /// </summary>
+        protected virtual IDictionary<string, string> ParsePage(Stream responseStream)
+        {
+            var dictionary = new Dictionary<string, string>();
+
+            string content;
+            using (var reader = new StreamReader(responseStream))
+                content = reader.ReadToEnd();
+
+            Regex metaTagPattern = new Regex(@"<meta\s*property\s*=\s*""(?<propertyName>[^""]+)""\s*content\s*=\s*""(?<propertyValue>[^""]+)""");
+            foreach (Match metaTagMatch in metaTagPattern.Matches(content))
+            {
+                dictionary.Add(metaTagMatch.Groups["propertyName"].Value, metaTagMatch.Groups["propertyValue"].Value);
+            }
+            // TODO: Instagram is changed and needs user to be authorized before accessing the content
+
+            var match = _graphqlScriptRegex.Match(content);
+            if (!match.Success)
+                throw new GrabParseException("Failed to obtain metadata from the Instagram page.");
+
+            return dictionary;
+        }
+
+        /// <summary>
+        /// Given the specified <paramref name="metaData"/>, generates proper <see cref="GrabResult"/>.
+        /// </summary>
+        protected virtual GrabResult GrabUsingMetadata(IDictionary<string, string> metaData)
+        {
+            var grabList = new List<IGrabbed>();
+
+            // extract metadata
+            var title = metaData.GetOrDefault("og:title");
+            var image = metaData.GetOrDefault("og:image");
+            var description = metaData.GetOrDefault("og:description");
+            var originalUri = new Uri(metaData.GetOrDefault("og:url"));
+            var type = metaData.GetOrDefault("og:type");
+            var video = metaData.GetOrDefault("og:video");
+            var video_secure_url = metaData.GetOrDefault("og:video:secure_url");
+            var video_type = metaData.GetOrDefault("og:video:type");
+            var video_width = int.Parse(metaData.GetOrDefault("og:video:width", "0"));
+            var video_height = int.Parse(metaData.GetOrDefault("og:video:height", "0"));
+
+            // grab image
+            if (!string.IsNullOrEmpty(image))
+                grabList.Add(new GrabbedImage(GrabbedImageType.Primary, null, new Uri(image)));
+
+            // grab video
+            if (!string.IsNullOrEmpty(video))
+            {
+                var format = new MediaFormat(video_type, MimeHelper.ExtractMimeExtension(video_type));
+                var vid = new GrabbedMedia(new Uri(video), null, format, MediaChannels.Both);
+                grabList.Add(vid);
+            }
+
+            // make result
+            var result = new GrabResult(originalUri, grabList)
+            {
+                Title = title,
+                Description = description,
+            };
+            return result;
+        }
+
+        #endregion
+
+        #region Methods
+
+        /// <inheritdoc />
+        public override bool Supports(Uri uri) => !string.IsNullOrEmpty(GrabId(uri));
+
+        /// <inheritdoc />
+        public override async Task<GrabResult> GrabAsync(Uri uri, CancellationToken cancellationToken,
+            GrabOptions options)
+        {
+            // init
+            var id = GrabId(uri);
+            if (id == null)
+                return null;
+
+            // generate standard Instagram link
+            uri = MakeStandardInstagramUri(id);
+
+            // download target page
+            Status.Update(null, WorkStatusType.DownloadingPage);
+            var client = HttpHelper.CreateClient(uri);
+            var response = await client.GetAsync(uri, cancellationToken);
+
+            // check response
+            CheckResponse(response);
+
+            using (var responseStream = await response.Content.ReadAsStreamAsync())
+            {
+                // parse page
+                var meta = ParsePage(responseStream);
+
+                // parse pairs
+                return GrabUsingMetadata(meta);
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/SharpGrabber/Internal/Grabbers/PornHubGrabber.cs
+++ b/src/SharpGrabber/Internal/Grabbers/PornHubGrabber.cs
@@ -1,0 +1,147 @@
+﻿using System;
+using System.Net.Http;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Jint;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using DotNetTools.SharpGrabber.Exceptions;
+using DotNetTools.SharpGrabber.Media;
+using System.Linq;
+
+namespace DotNetTools.SharpGrabber.Internal.Grabbers
+{
+    /// <summary>
+    /// Represents a PornHub.com grabber.
+    /// </summary>
+    public class PornHubGrabber : BaseGrabber
+    {
+        #region Compiled Regular Expressions
+        private static readonly Regex UrlMatcher = new Regex(@"^(https?://)?(www\.)?pornhub\.com/([^/]+)viewkey=(\w+).*$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex FlashVarsFinder = new Regex(@"((var|let)\s+(flashvars[\w_]+)(.|[\r\n])+)", RegexOptions.Multiline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        #endregion
+
+        #region Properties
+        /// <inheritdoc />
+        public override string Name { get; } = "PornHub";
+
+        /// <summary>
+        /// Will participate in a call to <see cref="string.Format(string, object)"/> with video 'viewkey' as argument.
+        /// </summary>
+        public string StandardUriFormat { get; set; } = "https://www.pornhub.com/view_video.php?viewkey={0}";
+        #endregion
+
+        #region Internal Methods
+        private static string GetViewId(string uriString)
+        {
+            var match = UrlMatcher.Match(uriString);
+            return !match.Success ? null : match.Groups[4].Value;
+        }
+
+        private static string GetViewId(Uri uri) => GetViewId(uri.ToString());
+
+        private Uri MakeStandardUri(string viewId) => new Uri(string.Format(StandardUriFormat, viewId));
+
+        private async Task<JObject> ExtractFlashVars(string script, string variableName)
+        {
+            return await Task.Run(() =>
+            {
+                var engine = new Engine();
+                engine.Execute(script);
+                var vars = engine.GetValue(variableName)?.ToObject();
+                if (vars == null)
+                    throw new GrabParseException("Failed to fetch flashvars object.");
+
+                return JsonConvert.DeserializeObject(JsonConvert.SerializeObject(vars)) as JObject;
+            });
+        }
+
+        protected virtual void Grab(GrabResult result, JObject vars, GrabOptions options)
+        {
+            if (options.Flags.HasFlag(GrabOptionFlag.GrabImages))
+            {
+                var image_url = new Uri(result.OriginalUri, vars.SelectToken("$.image_url").Value<string>());
+                result.Resources.Add(new GrabbedImage(GrabbedImageType.Primary, null, image_url));
+            }
+
+            result.Title = vars.SelectToken("$.video_title").Value<string>();
+            result.Statistics = new GrabStatisticInfo();
+            result.Statistics.Length = TimeSpan.FromSeconds(vars.SelectToken("$.video_duration").Value<int>());
+            var qualities = vars.SelectTokens("$.defaultQuality[*]").Select(t => t.Value<int>()).ToArray();
+
+            foreach (var quality in qualities)
+            {
+                var key = $"quality_{quality}p";
+                var url = vars.SelectToken($"$.{key}")?.Value<string>();
+                if (string.IsNullOrEmpty(url))
+                    continue;
+                var vid = new GrabbedMedia(new Uri(result.OriginalUri, url), null, new MediaFormat("video/mp4", "mp4"), MediaChannels.Both);
+                vid.Resolution = $"{quality}p";
+                vid.FormatTitle = $"MP4 {vid.Resolution}";
+                result.Resources.Add(vid);
+            }
+        }
+
+        /// <summary>
+        /// Accepts the whole source of target page and returns only the part that contains video player script.
+        /// </summary>
+        protected virtual string CutUsefulPart(string htmlContent)
+        {
+            void CheckIndex(int index)
+            {
+                if (index < 0)
+                    throw new GrabParseException("Failed to find the script containing flashvars.");
+            }
+
+            var from = htmlContent.IndexOf("flashvars_", StringComparison.OrdinalIgnoreCase);
+            CheckIndex(from);
+            from = htmlContent.LastIndexOf("<script", from, StringComparison.OrdinalIgnoreCase);
+            CheckIndex(from);
+            var to = htmlContent.IndexOf("</script>", from, StringComparison.OrdinalIgnoreCase);
+            CheckIndex(to);
+            return htmlContent.Substring(from, to - from);
+        }
+        #endregion
+
+        #region Methods
+        /// <inheritdoc />
+        public override bool Supports(Uri uri) => GetViewId(uri) != null;
+
+        /// <inheritdoc />
+        public override async Task<GrabResult> GrabAsync(Uri uri, CancellationToken cancellationToken, GrabOptions options)
+        {
+            // grab view id
+            var viewId = GetViewId(uri);
+            if (viewId == null)
+                return null;
+            uri = MakeStandardUri(viewId);
+
+            using (var client = HttpHelper.CreateClient())
+            {
+                // download content
+                var response = await client.GetAsync(uri, cancellationToken);
+                response.EnsureSuccessStatusCode();
+                var htmlContent = await response.Content.ReadAsStringAsync();
+
+                // cut the useful part of htmlContent to speed up regex look up
+                htmlContent = CutUsefulPart(htmlContent);
+
+                htmlContent = htmlContent.Insert(htmlContent.IndexOf("playerObjList."), "var playerObjList = {};\r\n");
+
+                // grab javascript flashvars
+                var match = FlashVarsFinder.Match(htmlContent);
+                if (!match.Success)
+                    throw new GrabParseException("Failed to locate flashvars.");
+                var variableName = match.Groups[3].Value;
+                var flashVars = await ExtractFlashVars(match.Groups[1].Value, variableName);
+
+                // generate result
+                var result = new GrabResult(uri);
+                Grab(result, flashVars, options);
+                return result;
+            }
+        }
+        #endregion
+    }
+}

--- a/src/SharpGrabber/SharpGrabber.csproj
+++ b/src/SharpGrabber/SharpGrabber.csproj
@@ -9,7 +9,6 @@
     <PackageProjectUrl>https://github.com/dotnettools/SharpGrabber</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/dotnettools/SharpGrabber/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/dotnettools/SharpGrabber</RepositoryUrl>
-    <PackageLicenseExpression>LGPL-3.0-or-later</PackageLicenseExpression>
     <PackageTags>youtube,instagram,download,grab,media,audio,video</PackageTags>
     <Authors>Javid Shoaei</Authors>
     <Product>SharpGrabber</Product>

--- a/tests/DotNetTools.SharpGrabber.Tests/GrabTests.cs
+++ b/tests/DotNetTools.SharpGrabber.Tests/GrabTests.cs
@@ -18,6 +18,16 @@ namespace DotNetTools.SharpGrabber.Tests
         }
 
         [Fact]
+        public async void Test_Instagram_VideoClip2()
+        {
+            var grabber = new InstagramGrabber();
+            var result =
+                await grabber.GrabAsync(
+                    new Uri("https://www.instagram.com/p/CIE3H_-DDJ1/?hl=en"));
+            Assert.Equal(2, result.Resources.Count);
+        }
+
+        [Fact]
         public async void Test_YouTube_Normal()
         {
             var grabber = new YouTubeGrabber();


### PR DESCRIPTION
Fixing instagram grabber and pornhub grabber and removing the PackagLicenseExpression line that caused the "NU5035 The PackageLicenseUrl is being deprecated and cannot be used in conjunction with..." compilation error